### PR TITLE
Improve handling of missing players.

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -14,7 +14,7 @@ class PlayersController < ApplicationController
         name = @player.player_name.gsub(" ", "_")
         redirect_to "/players/#{name}"
       else
-        redirect_to ranks_path, notice: 'Player not found.'
+        redirect_to ranks_path, notice: "Player '#{name}' not found."
       end
       return
     end 
@@ -354,6 +354,12 @@ class PlayersController < ApplicationController
 
     id = params[:search] || params[:id]
     @player = Player.find_player(id)
+
+    if not @player
+      redirect_to ranks_path, notice: "Player '#{id}' not found."
+      return
+    end
+
     if @player.potential_p2p > 0
       redirect_to ranks_path, notice: "Player '#{@player.player_name}' is not free to play."
       return
@@ -365,8 +371,16 @@ class PlayersController < ApplicationController
   def compare
     @player1 = Player.find_player(params[:player1])
     @player2 = Player.find_player(params[:player2])
-    if @player1 == false or @player2 == false
-      redirect_to ranks_path, notice: "Players not found."
+
+    player_not_found = nil
+    if not @player1
+      player_not_found = params[:player1]
+    elsif not @player2
+      player_not_found = params[:player2]
+    end
+
+    if player_not_found
+      redirect_to ranks_path, notice: "Player '#{player_not_found}' not found."
     end
   end
   


### PR DESCRIPTION
Just a small contribution to improve how queries are handled when a player doesn't exist in the database.

1. The `/players/` endpoint was returning an internal server error when a player wasn't found. The endpoint now redirects to the hiscores page with a message for the user.
2. Compare and search were not returning internal server errors but, I spruced up their error messages a little bit by echoing back the name of the player that wasn't found.

Some other thoughts:

1. I don't think an XSS vulnerability is created by echoing back the searched for name in the 'notice' string but, I don't know enough about rails to say this for sure.
2. These redirects, as well as some others in the file, might be better off as a 404 instead of a 302.