### PR TITLE
[DATA] All stat updates happen in a single sql UPDATE

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -174,7 +174,7 @@ class Player < ActiveRecord::Base
     return all_stats
   end
   
-  def check_hc_death
+  def check_hc_death(stats_hash)
     if player_acc_type == "HCIM"
       begin
         im_uri = URI.parse("https://services.runescape.com/m=hiscore_oldschool_ironman/index_lite.ws?player=#{self.player_name}")
@@ -184,7 +184,7 @@ class Player < ActiveRecord::Base
         hc_stats = hc_uri.read.split(" ")
         hc_xp = hc_stats[0].split(",")[2].to_f
         if hc_xp < (im_xp - 1000000) or (im_xp - hc_xp).to_f/hc_xp > 0.05
-          update_attribute(:player_acc_type, "IM")
+          stats_hash["player_acc_type"] = "IM"
         end
       rescue Exception => e   
         puts e.message 
@@ -215,7 +215,7 @@ class Player < ActiveRecord::Base
       combat = 3.4
     end
     
-    update_attribute(:combat_lvl, combat)
+    stats_hash["combat_lvl"] = combat
   end
 
   def get_ehp_type
@@ -251,26 +251,28 @@ class Player < ActiveRecord::Base
     stats_hash = calc_ehp(stats_hash)
     stats_hash = adjust_bonus_xp(stats_hash, bonus_xp)
 
-    check_hc_death
+    check_hc_death(stats_hash)
     calc_combat(stats_hash)
     
     stats_hash["ttm_lvl"] = time_to_max(stats_hash, "lvl")
     stats_hash["ttm_xp"] = time_to_max(stats_hash, "xp")
-    update_attributes(stats_hash)
-    
+
     if stats_hash["overall_ehp"] > 250 or Player.supporters.include?(player_name)
       TIMES.each do |time|
         xp = self.read_attribute("overall_xp_#{time}_start")
         if xp.nil? or xp == 0
-          update_player_start_stats(time)
+          update_player_start_stats(time, stats_hash)
         end
       end
       
-      check_record_gains
+      check_record_gains(stats_hash)
     end
+
+    self.attributes = stats_hash
+    self.save :validate => false
   end
   
-  def check_record_gains
+  def check_record_gains(stats_hash)
     SKILLS.each do |skill|
       xp = self.read_attribute("#{skill}_xp")
       ehp = self.read_attribute("#{skill}_ehp")
@@ -283,21 +285,21 @@ class Player < ActiveRecord::Base
           next
         end
         if max_xp.nil? or xp - start_xp > max_xp
-          update_attributes("#{skill}_xp_#{time}_max" => xp - start_xp)
+          stats_hash["#{skill}_xp_#{time}_max"] = xp - start_xp
         end
         if max_ehp.nil? or ehp - start_ehp > max_ehp
-          update_attributes("#{skill}_ehp_#{time}_max" => ehp - start_ehp)
+          stats_hash["#{skill}_ehp_#{time}_max"] = ehp - start_ehp
         end
       end
     end
   end
   
-  def update_player_start_stats(time)
+  def update_player_start_stats(time, stats_hash)
     SKILLS.each do |skill|
       xp = self.read_attribute("#{skill}_xp")
       ehp = self.read_attribute("#{skill}_ehp")
-      update_attributes("#{skill}_xp_#{time}_start" => xp)
-      update_attributes("#{skill}_ehp_#{time}_start" => ehp)
+      stats_hash["#{skill}_xp_#{time}_start"] = xp
+      stats_hash["#{skill}_ehp_#{time}_start"] = ehp
     end
   end
   


### PR DESCRIPTION
Improve performance when adding to high scores and when updating a player by combing all stat updates into a single SQL statement.

There's still a significant amount of latency when adding a new player to the high scores. Most of this seems to come from `determine_acc_type` because this method always makes 4 separate requests to the oldschool website.  