### PR TITLE
[ALGO] WIP: Improve check for HCIM's death

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 .idea/
 coverage/
 .DS_Store
+
+# Ignore .rbenv config.
+/.ruby-version

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -259,7 +259,7 @@ class Player < ActiveRecord::Base
     end
     Rails.logger.info "Updating #{player_name}"
 
-    # Stats are provided in parameters. Skip fetching from hiscores.
+    # Skip fetching from hiscores if stats are provided in parameters.
     unless stats
       stats, account_type = Hiscores
         .fetch_stats(player_name, account_type: player_acc_type)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -201,13 +201,6 @@ class Player < ActiveRecord::Base
     return player
   end
 
-  def hcim_dead?
-    # Skip check for UIMs who can never have been HCIMs.
-    return false if player_acc_type == 'UIM'
-
-    Hiscores.hcim_dead?(player_name)
-  end
-
   def check_p2p(stats_hash)
     return stats_hash[:potential_p2p] > 0
   end
@@ -270,17 +263,10 @@ class Player < ActiveRecord::Base
     stats_hash = calc_ehp(stats_hash)
     stats_hash = adjust_bonus_xp(stats_hash, bonus_xp)
 
-    # Check of current saved account type is still valid.
     updated_acc_type = Hiscores.verify_account_type(player_acc_type, player_name)
+
     if player_acc_type != updated_acc_type
       stats_hash.merge!(player_acc_type: updated_acc_type)
-    end
-
-    # Check if HCIM has died on the overall hiscore table.
-    # Normally this should have been picked up by the `verify_account_type`
-    # call, but this is sometimes not reliable.
-    if player_acc_type == 'HCIM' && updated_acc_type == 'HCIM' && hcim_dead?
-      stash_hash[:player_acc_type] = 'IM'
     end
 
     stats_hash = calc_combat(stats_hash)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -201,6 +201,13 @@ class Player < ActiveRecord::Base
     return player
   end
 
+  def hcim_dead?
+    # Skip check for UIMs who can never have been HCIMs.
+    return false if player_acc_type == 'UIM'
+
+    Hiscores.hcim_dead?(player_name)
+  end
+
   def check_p2p(stats_hash)
     return stats_hash[:potential_p2p] > 0
   end
@@ -263,10 +270,17 @@ class Player < ActiveRecord::Base
     stats_hash = calc_ehp(stats_hash)
     stats_hash = adjust_bonus_xp(stats_hash, bonus_xp)
 
+    # Check of current saved account type is still valid.
     updated_acc_type = Hiscores.verify_account_type(player_acc_type, player_name)
-
     if player_acc_type != updated_acc_type
       stats_hash.merge!(player_acc_type: updated_acc_type)
+    end
+
+    # Check if HCIM has died on the overall hiscore table.
+    # Normally this should have been picked up by the `verify_account_type`
+    # call, but this is sometimes not reliable.
+    if player_acc_type == 'HCIM' && updated_acc_type == 'HCIM' && hcim_dead?
+      stash_hash[:player_acc_type] = 'IM'
     end
 
     stats_hash = calc_combat(stats_hash)

--- a/app/services/base.rb
+++ b/app/services/base.rb
@@ -1,0 +1,25 @@
+module Base
+  def fetch(uri, max_attempts = 3)
+    raise TypeError, 'uri not an URI object' unless URI === uri
+
+    openuri_params = {
+      # Timeout durations for HTTP connection.
+      # 5 seconds should be max for opening and reading a connection.
+      open_timeout: 5,
+      read_timeout: 5
+    }
+
+    attempt = 0
+
+    begin
+      attempt += 1
+      return uri.read(openuri_params)
+    rescue OpenURI::HTTPError => e
+      # 404, no content.
+    rescue SocketError, Net::ReadTimeout => e
+      Rails.logger.warn "CML cannot be reached: #{e}"
+      sleep 2
+      retry if attempt < max_attempts
+    end
+  end
+end

--- a/app/services/cml.rb
+++ b/app/services/cml.rb
@@ -1,0 +1,115 @@
+require 'open-uri'
+
+class CML
+  class << self
+    CML_BASE_URL = 'https://crystalmathlabs.com/tracker/api.php'
+
+    def records_api_url(player_name)
+      URI.join(
+        CML_BASE_URL,
+        "?type=recordsofplayer&player=#{player_name}"
+      )
+    end
+
+    def datapoints_api_url(player_name, time)
+      URI.join(
+        CML_BASE_URL,
+        "?type=datapoints&player=#{player_name}&time=#{time}"
+      )
+    end
+
+    def fetch_records(player_name)
+      uri = records_api_url(player_name)
+      records = fetch(uri)
+      parse_records(records)
+    end
+
+    def parse_records(records)
+      return unless records
+      extracted_records = {}
+
+      skills = F2POSRSRanks::Application.config.skills
+      player_skills = Player.skills
+
+      records.split("\n").each.with_index do |record, idx|
+        skill = skills[idx]
+
+        if player_skills.include?(skill)
+          skill_records = record.split(',')
+          extracted_records.merge!(
+            "#{skill}_xp_day_max" => skill_records[0],
+            "#{skill}_xp_week_max" => skill_records[2],
+            "#{skill}_xp_month_max" => skill_records[4]
+          )
+        end
+      end
+
+      extracted_records
+    end
+
+    def fetch_exp(player_name, time_back)
+      now = DateTime.now
+
+      timedelta =
+        case time_back
+        when 'year'
+          (now - DateTime.new(now.year, 1, 1)).to_i
+        when 'month'
+          time_diff = (now - DateTime.new(now.year, now.month, 1)).to_i
+        else
+          raise ArgumentError, "time_back must be either 'year' or 'month'"
+        end
+
+      uri = datapoints_api_url(player_name, "#{timedelta}d")
+      records = fetch(uri)
+      parse_exp(records)
+    end
+
+    def parse_exp(records)
+      return unless records
+      records = records.split(',')
+      { 'overall_xp'     => xps[0],
+        'attack_xp'      => xps[1],
+        'defence_xp'     => xps[2],
+        'strength_xp'    => xps[3],
+        'hitpoints_xp'   => xps[4],
+        'ranged_xp'      => xps[5],
+        'prayer_xp'      => xps[6],
+        'magic_xp'       => xps[7],
+        'cooking_xp'     => xps[8],
+        'woodcutting_xp' => xps[9],
+        'fishing_xp'     => xps[11],
+        'firemaking_xp'  => xps[12],
+        'crafting_xp'    => xps[13],
+        'smithing_xp'    => xps[14],
+        'mining_xp'      => xps[15],
+        'runecraft_xp'   => xps[21] }
+    end
+
+    private
+
+    def fetch(uri, max_attempts = 3)
+      raise TypeError, 'uri not an URI object' unless URI == uri
+
+      openuri_params = {
+        # Timeout durations for HTTP connection.
+        # 5 seconds should be max for opening and reading a connection.
+        open_timeout: 5,
+        read_timeout: 5
+      }
+
+      attempt = 0
+
+      begin
+        attempt += 1
+        return uri.read(openuri_params)
+      rescue OpenURI::HTTPError => e
+        # 404, no content.
+      rescue SocketError, Net::ReadTimeout => e
+        Rails.logger.warn "CML cannot be reached: #{e}"
+        sleep 2
+        retry if attempt < max_attempts
+      end
+    end
+  end
+end

--- a/app/services/cml.rb
+++ b/app/services/cml.rb
@@ -14,17 +14,17 @@ class CML
     def fetch_exp(player_name, time_back)
       now = DateTime.now
 
-      timedelta =
+      deltatime =
         case time_back
         when 'year'
-          (now - DateTime.new(now.year, 1, 1)).to_i
+          now - DateTime.new(now.year, 1, 1)
         when 'month'
-          time_diff = (now - DateTime.new(now.year, now.month, 1)).to_i
+          now - DateTime.new(now.year, now.month, 1)
         else
           raise ArgumentError, "time_back must be either 'year' or 'month'"
         end
 
-      uri = datapoints_api_url(player_name, "#{timedelta}d")
+      uri = datapoints_api_url(player_name, "#{deltatime.to_i}d")
       records = fetch(uri)
       parse_exp(records)
     end

--- a/app/services/cml.rb
+++ b/app/services/cml.rb
@@ -1,6 +1,8 @@
 require 'open-uri'
 
 class CML
+  extend Base
+
   class << self
     CML_BASE_URL = 'https://crystalmathlabs.com/tracker/api.php'
 
@@ -84,32 +86,6 @@ class CML
         'smithing_xp'    => xps[14],
         'mining_xp'      => xps[15],
         'runecraft_xp'   => xps[21] }
-    end
-
-    private
-
-    def fetch(uri, max_attempts = 3)
-      raise TypeError, 'uri not an URI object' unless URI == uri
-
-      openuri_params = {
-        # Timeout durations for HTTP connection.
-        # 5 seconds should be max for opening and reading a connection.
-        open_timeout: 5,
-        read_timeout: 5
-      }
-
-      attempt = 0
-
-      begin
-        attempt += 1
-        return uri.read(openuri_params)
-      rescue OpenURI::HTTPError => e
-        # 404, no content.
-      rescue SocketError, Net::ReadTimeout => e
-        Rails.logger.warn "CML cannot be reached: #{e}"
-        sleep 2
-        retry if attempt < max_attempts
-      end
     end
   end
 end

--- a/app/services/cml.rb
+++ b/app/services/cml.rb
@@ -2,9 +2,34 @@ require 'open-uri'
 
 class CML
   extend Base
+  CML_BASE_URL = 'https://crystalmathlabs.com/tracker/api.php'
 
   class << self
-    CML_BASE_URL = 'https://crystalmathlabs.com/tracker/api.php'
+    def fetch_records(player_name)
+      uri = records_api_url(player_name)
+      records = fetch(uri)
+      parse_records(records)
+    end
+
+    def fetch_exp(player_name, time_back)
+      now = DateTime.now
+
+      timedelta =
+        case time_back
+        when 'year'
+          (now - DateTime.new(now.year, 1, 1)).to_i
+        when 'month'
+          time_diff = (now - DateTime.new(now.year, now.month, 1)).to_i
+        else
+          raise ArgumentError, "time_back must be either 'year' or 'month'"
+        end
+
+      uri = datapoints_api_url(player_name, "#{timedelta}d")
+      records = fetch(uri)
+      parse_exp(records)
+    end
+
+    private
 
     def records_api_url(player_name)
       URI.join(
@@ -18,12 +43,6 @@ class CML
         CML_BASE_URL,
         "?type=datapoints&player=#{player_name}&time=#{time}"
       )
-    end
-
-    def fetch_records(player_name)
-      uri = records_api_url(player_name)
-      records = fetch(uri)
-      parse_records(records)
     end
 
     def parse_records(records)
@@ -47,24 +66,6 @@ class CML
       end
 
       extracted_records
-    end
-
-    def fetch_exp(player_name, time_back)
-      now = DateTime.now
-
-      timedelta =
-        case time_back
-        when 'year'
-          (now - DateTime.new(now.year, 1, 1)).to_i
-        when 'month'
-          time_diff = (now - DateTime.new(now.year, now.month, 1)).to_i
-        else
-          raise ArgumentError, "time_back must be either 'year' or 'month'"
-        end
-
-      uri = datapoints_api_url(player_name, "#{timedelta}d")
-      records = fetch(uri)
-      parse_exp(records)
     end
 
     def parse_exp(records)

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -20,6 +20,13 @@ class Hiscores
       )
     end
 
+    def hcim_table_url(player_name)
+      URI.join(
+        'https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/overall.ws',
+        "?user=#{player_name}"
+      )
+    end
+
     def parse_stats(data, restrict_fields = [])
       stats = { potential_p2p: 0 }
 
@@ -93,6 +100,14 @@ class Hiscores
         sleep 2
         retry if attempt < max_attempts
       end
+    end
+
+    def hcim_dead?(player_name)
+      uri = hcim_table_url(player_name)
+      page = Nokogiri::HTML(open(uri))
+      page.xpath('//*[@id="contentHiscores"]/table/tbody/tr[contains(@class, "--dead")]/td/a/span')
+          .first
+          .present?
     end
 
     # Checks if given `account_type` for `player_name` is still valid.

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -86,7 +86,10 @@ class Hiscores
 
     def hcim_dead?(player_name)
       uri = hcim_table_url(player_name)
-      page = Nokogiri::HTML(open(uri))
+      content = fetch(uri)
+      return false unless content
+
+      page = Nokogiri::HTML(content)
       page.xpath('//*[@id="contentHiscores"]/table/tbody/tr[contains(@class, "--dead")]/td/a/span')
           .first
           .present?

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -118,11 +118,11 @@ class Hiscores
       end
 
       # Find the mode with the highest amount of total exp.
-      _, idx = overall_xp_each_mode
+      _, most_exp_idx = overall_xp_each_mode
         .map.with_index.sort_by { |xp, idx| [-xp, idx] }
         .first
 
-      modes[idx]
+      modes[most_exp_idx]
     end
 
     def determine_account_type(player_name)
@@ -132,7 +132,7 @@ class Hiscores
         begin
           return verify_account_type(type, player_name)
         rescue  # Non-existent hiscores lookup for a mode raises exception.
-          # Attempt to retrieve hiscores for next mode.
+          # Proceed to attempt to retrieve hiscores for next mode.
           next
         end
       end

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -20,6 +20,13 @@ class Hiscores
       )
     end
 
+    def hcim_table_url(player_name)
+      URI.join(
+        'https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/overall.ws',
+        "?user=#{player_name}"
+      )
+    end
+
     def parse_stats(data, restrict_fields = [])
       stats = { potential_p2p: 0 }
 
@@ -76,6 +83,14 @@ class Hiscores
       parse_stats(data, parse_fields)
     rescue OpenURI::HTTPError
       raise RuntimeError, "player #{player_name} is not a(n) #{account_type}"
+    end
+
+    def hcim_dead?(player_name)
+      uri = hcim_table_url(player_name)
+      page = Nokogiri::HTML(open(uri))
+      page.xpath('//*[@id="contentHiscores"]/table/tbody/tr[contains(@class, "--dead")]/td/a/span')
+          .first
+          .present?
     end
 
     # Checks if given `account_type` for `player_name` is still valid.

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -1,6 +1,8 @@
 require 'open-uri'
 
 class Hiscores
+  extend Base
+
   class << self
     def api_url(account_type, player_name)
       unless account_type.in? Player.account_types
@@ -66,40 +68,20 @@ class Hiscores
 
     def player_exists?(player_name)
       # A player does not exist if the player does not have 'Reg' hiscores.
-      fetch_stats('Reg', player_name)
-      true
-    rescue
-      false
+      fetch_stats('Reg', player_name).present?
     end
 
     def fetch_stats(account_type, player_name, parse: false, parse_fields: [])
       uri = api_url(account_type, player_name)
 
-      openuri_params = {
-        # Timeout durations for HTTP connection.
-        # 5 seconds should be max for opening and reading a connection.
-        open_timeout: 5,
-        read_timeout: 5
-      }
+      res = fetch(uri)
+      return unless res
 
-      max_attempts = 3
-      attempt = 0
+      data = res.split("\n")
+      return data unless parse
 
-      begin
-        res = uri.read
-        data = res.split("\n")
-
-        return data unless parse
-
-        parse_fields = [parse_fields] unless Array === parse_fields
-        return parse_stats(data, parse_fields)
-      rescue OpenURI::HTTPError => e
-        raise RuntimeError, "player #{player_name} is not a(n) #{account_type}"
-      rescue SocketError, Net::ReadTimeout => e
-        Rails.logger.warn "Runescape Hiscores cannot be reached: #{e}"
-        sleep 2
-        retry if attempt < max_attempts
-      end
+      parse_fields = [parse_fields] unless Array === parse_fields
+      return parse_stats(data, parse_fields)
     end
 
     def hcim_dead?(player_name)
@@ -131,6 +113,7 @@ class Hiscores
 
       overall_xp_each_mode = modes.map do |mode|
         stats = fetch_stats(mode, player_name, parse: true, parse_fields: 'overall')
+        raise RuntimeError, "#{player_name} is not a(n) #{mode}" unless stats
         stats['overall_xp']
       end
 

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -20,13 +20,6 @@ class Hiscores
       )
     end
 
-    def hcim_table_url(player_name)
-      URI.join(
-        'https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/overall.ws',
-        "?user=#{player_name}"
-      )
-    end
-
     def parse_stats(data, restrict_fields = [])
       stats = { potential_p2p: 0 }
 
@@ -100,14 +93,6 @@ class Hiscores
         sleep 2
         retry if attempt < max_attempts
       end
-    end
-
-    def hcim_dead?(player_name)
-      uri = hcim_table_url(player_name)
-      page = Nokogiri::HTML(open(uri))
-      page.xpath('//*[@id="contentHiscores"]/table/tbody/tr[contains(@class, "--dead")]/td/a/span')
-          .first
-          .present?
     end
 
     # Checks if given `account_type` for `player_name` is still valid.

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -4,31 +4,6 @@ class Hiscores
   extend Base
 
   class << self
-    def api_url(account_type, player_name)
-      unless account_type.in? Player.account_types
-        raise ArgumentError, 'account type not recognized'
-      end
-
-      path_suffix = {
-        HCIM: '_hardcore_ironman',
-        UIM: '_ultimate',
-        IM: '_ironman'
-      }
-
-      URI.join(
-        'https://services.runescape.com',
-        "m=hiscore_oldschool#{path_suffix[account_type.to_sym]}/index_lite.ws",
-        "?player=#{player_name}"
-      )
-    end
-
-    def hcim_table_url(player_name)
-      URI.join(
-        'https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/overall.ws',
-        "?user=#{player_name}"
-      )
-    end
-
     def fetch_stats(player_name, account_type: nil)
       parse_fields = [parse_fields] unless Array === parse_fields
 
@@ -92,6 +67,31 @@ class Hiscores
     end
 
     private
+
+    def api_url(account_type, player_name)
+      unless account_type.in? Player.account_types
+        raise ArgumentError, 'account type not recognized'
+      end
+
+      path_suffix = {
+        HCIM: '_hardcore_ironman',
+        UIM: '_ultimate',
+        IM: '_ironman'
+      }
+
+      URI.join(
+        'https://services.runescape.com',
+        "m=hiscore_oldschool#{path_suffix[account_type.to_sym]}/index_lite.ws",
+        "?player=#{player_name}"
+      )
+    end
+
+    def hcim_table_url(player_name)
+      URI.join(
+        'https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/overall.ws',
+        "?user=#{player_name}"
+      )
+    end
 
     def parse_stats(data, restrict_fields = [])
       stats = { potential_p2p: 0 }


### PR DESCRIPTION
**Please review #16 first, since this PR builds on PR #16. Afterwards, the WIP tag can be removed from this PR's title.**

According to @vmeow, there are a handful false positives when checking if a player has been downgraded from HCIM to IM on death. The previous approach to avoid these FPs has been written in commit https://github.com/vmeow/f2pehp/commit/ff32d341dbdcff39a384ddb261c954ce893d3a7d. This "threshold" of 5% exp  between HCIM and IM total exp is an estimation, and not guaranteed accurate.

In this PR I wrote a simple method that checks the HCIM death status from the overall hiscores table via HTML scraping. It checks if the table descriptor's class has a `*--dead` class name. If this is the case, the HCIM has died. This ensures the correctness of our HCIM's death detection with 100% certainty (assuming the OSRS Hiscores table is correct).