### PR TITLE
Fix issues with account type retrieval and hiscores' inresponsiveness

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -305,9 +305,7 @@ class Player < ActiveRecord::Base
       return false
     end
 
-    unless account_type
-      return false
-    end
+    return false unless account_type
 
     if player_acc_type != account_type
       return update_attribute(:player_acc_type, account_type)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -284,7 +284,7 @@ class Player < ActiveRecord::Base
         stats[:player_acc_type] = account_type
       elsif player_acc_type == 'HCIM' && account_type == 'HCIM' && hcim_dead?
         # Check if HCIM has died on the overall hiscores table.
-        # Normally this should have been picked up by the `verify_account_type`
+        # Normally this should have been picked up by the `fetch_stats`
         # call, but this is sometimes not reliable.
         stats[:player_acc_type] = 'IM'
       end
@@ -311,7 +311,7 @@ class Player < ActiveRecord::Base
       return update_attribute(:player_acc_type, account_type)
     elsif player_acc_type == 'HCIM' && account_type == 'HCIM' && hcim_dead?
       # Check if HCIM has died on the overall hiscores table.
-      # Normally this should have been picked up by the `verify_account_type`
+      # Normally this should have been picked up by the `fetch_stats`
       # call, but this is sometimes not reliable.
       return update_attribute(:player_acc_type, 'IM')
     end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -276,11 +276,11 @@ class Player < ActiveRecord::Base
 
       if player_acc_type != account_type
         stats[:player_acc_type] = account_type
-      elsif player_acc_type == 'HCIM' && hcim_dead?
+      elsif player_acc_type == 'HCIM' && account_type == 'HCIM' && hcim_dead?
         # Check if HCIM has died on the overall hiscores table.
         # Normally this should have been picked up by the `verify_account_type`
         # call, but this is sometimes not reliable.
-        stash_hash[:player_acc_type] = 'IM'
+        stats[:player_acc_type] = 'IM'
       end
     end
 

--- a/app/services/base.rb
+++ b/app/services/base.rb
@@ -17,9 +17,10 @@ module Base
     rescue OpenURI::HTTPError => e
       # 404, no content.
     rescue SocketError, Net::ReadTimeout => e
-      Rails.logger.warn "CML cannot be reached: #{e}"
+      Rails.logger.warn "[#{attempt}/#{max_attempts}] #{uri} could not be reached: #{e}"
       sleep 2
       retry if attempt < max_attempts
+      raise e
     end
   end
 end

--- a/app/services/hiscores.rb
+++ b/app/services/hiscores.rb
@@ -3,6 +3,10 @@ require 'open-uri'
 class Hiscores
   extend Base
 
+  REG_MODE = %w[Reg].freeze
+  IRONMAN_MODES = %w[UIM HCIM IM].freeze
+  ALL_MODES = %w[UIM HCIM IM Reg].freeze
+
   class << self
     def fetch_stats(player_name, account_type: nil)
       parse_fields = [parse_fields] unless Array === parse_fields
@@ -15,16 +19,16 @@ class Hiscores
           # For IM:   [IM, Reg]
           # For Reg:  [Reg]
           case account_type
-          when 'Reg'
-            ['Reg']
-          when *%w[UIM HCIM IM]
+          when *REG_MODE
+            REG_MODE
+          when *IRONMAN_MODES
             ancestors = Player.account_type_ancestors[account_type.to_sym]
             [account_type] + ancestors
           else
             raise ArgumentError, 'account type not recognized'
           end
         else
-          %w[UIM HCIM IM Reg]
+          ALL_MODES
         end
 
       stats = []
@@ -34,7 +38,11 @@ class Hiscores
 
       uri_per_mode.each_with_index do |uri, mode_idx|
         threads << Thread.new(uri, mode_idx, stats) do |uri, mode_idx, stats|
+          # Raise exceptions in main thread so they can be caught.
+          Thread.current.abort_on_exception = true
           res = fetch(uri)
+
+          # No hiscores data for this mode, skip.
           next unless res
 
           data = res.split("\n")
@@ -57,7 +65,14 @@ class Hiscores
 
     def hcim_dead?(player_name)
       uri = hcim_table_url(player_name)
-      content = fetch(uri)
+
+      begin
+        content = fetch(uri)
+      rescue SocketError, Net::ReadTimeout
+        Rails.logger.warn "#{player_name}'s HCIM hiscores retrieval failed"
+        return false
+      end
+
       return false unless content
 
       page = Nokogiri::HTML(content)


### PR DESCRIPTION
Certain player have recently been assigned a wrong account type, and they have been unable to reset the account type with the "wrong account type?" link.

The issue was that when a lookup of hiscores for a certain mode (e.g. UIM) failed 3 times, it returned `nil` and continued to retrieve hiscores for the next lower-order rank. Because of this, players may be updated with the wrong account type. I fixed this by letting the hiscores' fetch threads raise the `Socket` and `ReadTimeout` exceptions to the main thread after 3 failed attempts. The user will then get redirected to their hiscores tab with the notice that the player could not be updated, suggesting to try again.

The `check_acc_type` that is ran when clicking the "wrong account type?" link was broken since last PR, because I accidentally removed the underlying Player.#check_acc_type method. I reintroduced and updated this method, and ensured it handles the before mentioned potential responsiveness issues.

All in all, this should fix the issues that users experienced when they got assigned a wrong player account type.

I also fixed the rollback/hotfix for checking for HCIM death.