### PR TITLE
Adding meta

### DIFF
--- a/app/assets/stylesheets/players.scss.erb
+++ b/app/assets/stylesheets/players.scss.erb
@@ -285,6 +285,12 @@ div {
   padding: 5px;
   margin-bottom: 20px;
 }
+.motd hr {
+    border: none;
+    height: 1px;
+    color: rgba(255, 255, 255, 0.15);
+    background-color: rgba(255, 255, 255, 0.15);
+}
 
 .supporters {
   margin: auto;

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -7,6 +7,11 @@ require 'will_paginate/array'
 class PlayersController < ApplicationController
   before_action :set_player, only: %i[show edit update destroy]
 
+  def set_default_description
+    @default_description = 'F2P.wiki is an open source Old School RuneScape hiscores for Free-to-play players. It also includes EHP tracking, information about meta changes, and various F2P Old School RuneScape tools.'
+  end
+  before_action :set_default_description
+
   def search_player_if_needed
     if params[:search]
       name = Player.sanitize_name(params[:search])

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
+  <meta name="description" content="<%= @description ? @description : 'F2P.wiki is an open source Old School RuneScape hiscores for Free-to-play players. It also includes EHP tracking, information about meta changes, and various F2P Old School RuneScape tools.' %>">
 </head>
 <body>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,21 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
-  <meta name="description" content="<%= @description ? @description : 'F2P.wiki is an open source Old School RuneScape hiscores for Free-to-play players. It also includes EHP tracking, information about meta changes, and various F2P Old School RuneScape tools.' %>">
+  <meta name="description" content="<%= @description ? @description : @default_description %>">
+
+  <!-- Facebook OG Tags -->
+  <meta property="og:type" content="website" /> 
+  <meta property="og:title" content="<%= @title %>" />
+  <meta property="og:description" content="<%= @description ? @description : @default_description %>" />
+  <meta property="og:image" content="<%= image_url("f2pwiki_500.png") %>" />
+  <meta property="og:url" content="<%= url_for(only_path: false) %>" />
+  <meta property="og:site_name" content="F2P Wiki" />
+
+  <!-- Twiter Tags -->
+  <meta name="twitter:title" content="<%= @title %>">
+  <meta name="twitter:description" content="<%= @description ? @description : @default_description %>" />
+  <meta name="twitter:image" content="<%= image_url("f2pwiki_500.png") %>" />
+  <meta name="twitter:url" content="<%= url_for(only_path: false) %>" />
 </head>
 <body>
 

--- a/app/views/players/calcs.html.haml
+++ b/app/views/players/calcs.html.haml
@@ -1,4 +1,5 @@
 - @title = "Calcs" 
+- @description = "Combat level and DPS calculators." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/changelog.html.haml
+++ b/app/views/players/changelog.html.haml
@@ -1,4 +1,5 @@
 - @title = "F2P OSRS/Wiki Changelog" 
+- @description = "A log of all of the F2P OSRS and F2P.wiki updates." 
 = favicon_link_tag "rs_favicon.png"
 = link_to image_tag("f2pwiki_500.png"), players_path
 

--- a/app/views/players/combat.html.haml
+++ b/app/views/players/combat.html.haml
@@ -1,4 +1,5 @@
 - @title = "Calcs" 
+- @description = "Combat level and DPS calculators." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/compare.html.haml
+++ b/app/views/players/compare.html.haml
@@ -1,4 +1,5 @@
 - @title = "Personal Hiscores" 
+- @description = "View the personal hiscores of a player." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/donate.html.haml
+++ b/app/views/players/donate.html.haml
@@ -1,4 +1,5 @@
 - @title = "About Us" 
+- @description = "Help support F2P.wiki by donating and receive special perks." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/dps.html.haml
+++ b/app/views/players/dps.html.haml
@@ -1,4 +1,5 @@
 - @title = "Calcs" 
+- @description = "Combat level and DPS calculators." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/ehp.html.haml
+++ b/app/views/players/ehp.html.haml
@@ -1,4 +1,5 @@
 - @title = "F2P EHP" 
+- @description = "List of F2P EHP rates for each account type and the associated methods." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/fake.html.haml
+++ b/app/views/players/fake.html.haml
@@ -1,4 +1,5 @@
 - @title = "F2P Hall of Shame" 
+- @description = "A list of confirmed fake F2P accounts." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/index.html.haml
+++ b/app/views/players/index.html.haml
@@ -9,20 +9,26 @@
       %h1 News
       %h6
         = "Jan 28, 2020: Just to re-iterate, F2P.wiki does NOT treat name changes of any kind as false F2P. Including but not limited to Jagex forced name changes, historical Funorb name changes, bond name changes, etc., and we never will. Yes, even bond name changes."
+      %hr
       %h6
         = "Our sincerest apologies for the recent outages on the site. Due to changes to the official Jagex hiscores, all hiscores including F2P.wiki, CML, and even Jagex official hiscores have been experiencing massive issues. For example, the official hiscores has been unresponsive for the past 2 hours as of writing this. As a result, we have unfortunately had to make the decision to no longer automatically update non-supporter players below 250 EHP. Manual updates may still be made."
+      %hr
       %h6 
         = "Congratulations to the Cunnilinguists for winning the"
         = link_to "F2P Team Rumble competition!", "https://docs.google.com/spreadsheets/d/1iQkonWQCp-gNHp7dija630BWsYl-SjUKFQd9SwaE9z8/edit#gid=0"
+      %hr
       %h6
         = "v1.64 release: LMS hiscores and Obor/Bryophyta kill count hiscores. Ranks will fill in with the next site-wide player updates."
+      %hr
       %h6
         = "v1.63 release: Lowest Level hiscores, ability to reset filters, ability to filter out inactive players, fix to non-combat hiscores"
+      %hr
       %h6
         = "Bargan is free."
+      %hr
       %h6 
         = "Due to a recent increase in accounts de-ironing or losing hardcore status, we have released a feature to check account type at the bottom right corner of each player's Personal Hiscores page."
-
+      %hr
       %h6
         = "Congratulations to the winners of the Free to Play clan's"
         = link_to "Buddy-Up Summer Skilling Competition!", "https://www.reddit.com/r/W385/comments/cd8v54/summer_f2p_skilling_competition/"
@@ -42,30 +48,37 @@
         %br
         = link_to "Irondish", "players/Irondish"
         = link_to "DansPotatoe", "players/DansPotatoe"
-      %br
-      %br
+      %hr
       %h6
         = "v1.62 release: 99 and 200m count have been released on the hiscores."
+      %hr
       %h6
         = "v1.61 release: internal site upgrades and refactoring. Open sourcing of"
         = link_to "our GitHub repo!", "https://github.com/vmeow/f2pehp/"
+      %hr
       %h6
         = "v1.60 release: Major site overhaul with updated EHP, implementation of bonus XP algorithms, and general internal improvements."
+      %hr
       %h6
         = "Our site has encountered multiple issues regarding beginner clues and the official beginner clues hiscores. As a result, many players were deleted, along with tracking and record data. We apologize for the inconvenience, and we are doing our best to resolve the issue. Thanks for your patience."
+      %hr
       %h6
         = "Thanks to"
         = link_to "DansPotatoe", "players/DansPotatoe"
         = "for sharing his"
         = link_to "level 3 UIM guide!", "https://pastebin.com/raw/eh3zwb2a"
+      %hr
       %h6
         = "v1.52 release: Overall (no combats) hiscores has been released!"
+      %hr
       %h6 
         = "v1.51 release: We're happy to announce the Time to Max feature on the hiscores!"
+      %hr
       %h6
         = "Shoutout to Pawz and his new videos on Efficient F2P Maxing: "
         = link_to "Part 1,", "https://www.youtube.com/watch?v=BOSVsLQOXcw"
         = link_to "Part 2", "https://www.youtube.com/watch?v=B7TlGwXalCg"
+      %hr
       %h6 
         = "v1.50 release: The long awaited"
         = link_to "EHP and XP tracking", tracking_path

--- a/app/views/players/links.html.haml
+++ b/app/views/players/links.html.haml
@@ -1,4 +1,5 @@
 - @title = "Links" 
+- @description = "A catalog of useful links related to F2P OSRS." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/names.html.haml
+++ b/app/views/players/names.html.haml
@@ -1,3 +1,5 @@
+- @title = "Names" 
+- @description = "A list of all accounts currently on F2P.wiki." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 %p#notice= notice

--- a/app/views/players/oldchangelog.html.haml
+++ b/app/views/players/oldchangelog.html.haml
@@ -1,4 +1,5 @@
-- @title = "F2P Wiki Changelog" 
+- @title = "Old F2P Wiki Changelog" 
+- @description = "Old Changelog (before v1.0 public release)." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/possible_fakes.html.haml
+++ b/app/views/players/possible_fakes.html.haml
@@ -1,4 +1,5 @@
 - @title = "Possible F2P Fakes" 
+- @description = "A list of accounts which may or may not be pure F2P." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}

--- a/app/views/players/records.html.haml
+++ b/app/views/players/records.html.haml
@@ -1,4 +1,5 @@
 - @title = "Record Gains" 
+- @description = "F2P account XP and EHP records set for Day, Week, Month and Year." 
 = link_to image_tag("f2pwiki_500.png"), players_path
 
 = render :partial => "header.html.haml",  :locals => {notice: notice}


### PR DESCRIPTION
Added these horizontal rules on the /players page to help distinguish between news items

![image](https://user-images.githubusercontent.com/2869411/74108780-812b1d80-4be2-11ea-9064-7ecb9505688e.png)

Then added a default meta description and a specific meta description on most pages

Then added the meta tags required for cards (an example of a card is shown below)
![image](https://user-images.githubusercontent.com/2869411/74108807-aae44480-4be2-11ea-8aee-2e51143ecec8.png)

