### PR TITLE
Force ssl in config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Force SSL
+  config.force_ssl = true
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
There's some[ good security reasons](https://stackoverflow.com/questions/15676596/what-does-force-ssl-do-in-rails) to do this, but it's also just good practice that everyone uses ssl

You may want to test this on staging server first tho to make sure nothing breaks (assuming staging uses same production.rb file). Hard to test in local env.

Also didn't see a staging branch.