### PR TITLE
Add nightmare boss as p2p_minigame

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -75,6 +75,7 @@ F2POSRSRanks::Application.configure do
                      "p2p_minigame",
                      "p2p_minigame",
                      "p2p_minigame",
+                     "p2p_minigame",
                      "obor_kc",
                      "p2p_minigame",
                      "p2p_minigame",


### PR DESCRIPTION
I noticed a number of players are no longer showing on f2p.wiki due to being classified as p2p:

![image](https://user-images.githubusercontent.com/1018141/74495077-a77eef00-4f3b-11ea-86a4-c9336c7fed8c.png)


![image](https://user-images.githubusercontent.com/1018141/74495073-a221a480-4f3b-11ea-8b58-d84e7a32441b.png)

I believe it might be due to the Nightmare boss being added in game, so the skill/minigame mappings need to be updated.

I have tested locally and with this change the valid missing players can be added


