### PR TITLE
[CALC] Add option to include cwars boots +1 str bonus in melee DPS

### DIFF
--- a/app/assets/javascripts/combat-dps.js
+++ b/app/assets/javascripts/combat-dps.js
@@ -26,6 +26,7 @@ function combatDPS() {
 
         var meleeWeapon = getAttributeValue("melee_weapon");
         var meleeNeck = getAttributeValue("melee_neck");
+        var meleeBoots = getAttributeChecked("melee_boots");
 
         var mob = getAttributeValue("mob_name");
         var customStats = getAttributeChecked('custom_stats');
@@ -125,6 +126,10 @@ function combatDPS() {
                 break;
             default:
                 break;
+        }
+
+        if (meleeBoots) {
+            strBonus += 1;
         }
         
         // Effective str
@@ -846,6 +851,7 @@ function combatDPS() {
         $('#melee_style').change(dps);
         $('#melee_weapon').change(dps);
         $('#melee_neck').change(dps);
+        $('#melee_boots').change(dps);
         $('#mob_name').change(dps);
         $('#custom_stats').change(dps);
         $('#pvp').change(dps);

--- a/app/views/players/dps.html.haml
+++ b/app/views/players/dps.html.haml
@@ -32,20 +32,15 @@
         %td= ""
       %tr
         %td= ""
-      %tr
-        %td= ""
-      %tr
-        %td= ""
-      %tr
-        %td= ""
-      %tr
-        %td= ""
       %tr 
         %td= label_tag "Weapon"
         %td= select_tag "melee_weapon", options_for_select(["Rune scimitar", "Rune sword", "Rune longsword", "Rune battleaxe", "Rune 2h sword", "Hill giant club", "Adamant scimitar", "Adamant sword", "Adamant 2h sword", "Event rpg", "None"], "Rune scimitar"), style: "width: 135px;", :include_blank => true
       %tr
         %td= label_tag "Neck Slot"
         %td= select_tag "melee_neck", options_for_select(["Amulet of power", "Amulet of strength", "Amulet of accuracy"]), style: "width: 135px;", :include_blank => true
+      %tr
+        %td= label_tag "Gold boots?"
+        %td= check_box_tag "melee_boots", 1
       %tr
         %td= ""
       %tr


### PR DESCRIPTION
Update the DPS calculator to include the +1 strength bonus from the new gold decorative boots.