### PR TITLE
Sort some skills by xp not ehp as ehp is mostly 0

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -297,11 +297,7 @@ class PlayersController < ApplicationController
       @skill = "overall"
       params[:skill] = "overall"
       session[:skill] = "overall"
-    end
-
-    if @sort_by == {}
-      @sort_by = "ehp"
-    end
+    end 
 
     if params[:filters_] != session[:filters_] || params[:sort_by] != session[:sort_by] || params[:skill] != session[:skill] || params[:show_limit] != session[:show_limit] || params[:restrictions] != session[:restrictions] || params[:filter_inactive] != session[:filter_inactive]
       session[:filters_] = @filters
@@ -310,6 +306,14 @@ class PlayersController < ApplicationController
       session[:sort_by] = @sort_by
       session[:show_limit] = @show_limit
       session[:filter_inactive] = @filter_inactive
+    end
+
+    # Sort some skills by xp not ehp as ehp is mostly 0
+    @skills_by_xp = ['magic', 'mining']
+    if @sort_by == {} && @skills_by_xp.include?(@skill)
+      @sort_by = "xp"
+    elsif @sort_by == {}
+      @sort_by = "ehp"
     end
 
     if @skill.include?("ttm")


### PR DESCRIPTION
#83 

Have just done magic and mining. Complete 0 ehp skills such as hitpoints are always sorted by xp as all game modes have 0 ehp. Mining is 0 ehp for all but regs meaning it makes sense to compare all game modes to regs