### PR TITLE
Data clans

### DIFF
--- a/app/controllers/clans_controller.rb
+++ b/app/controllers/clans_controller.rb
@@ -250,10 +250,10 @@ class ClansController < ApplicationController
       when "ehp", "lvl"
         @sort_by = "ehp"
         @player_ehp_header = 'hilite'
-        ordering = "#{@skill}_ehp - IFNULL(#{@skill}_ehp_#{@time}_start, 100000) DESC, #{@skill}_xp - IFNULL(#{@skill}_xp_#{@time}_start, 1000000000) DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
+        ordering = "#{@skill}_ehp - COALESCE(#{@skill}_ehp_#{@time}_start, 100000) DESC, #{@skill}_xp - COALESCE(#{@skill}_xp_#{@time}_start, 1000000000) DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
       when "xp"
         @player_xp_header = 'hilite'
-        ordering = "#{@skill}_xp - IFNULL(#{@skill}_xp_#{@time}_start, 1000000000) DESC, #{@skill}_ehp - IFNULL(#{@skill}_ehp_#{@time}_start, 100000) DESC, #{@skill}_xp DESC"
+        ordering = "#{@skill}_xp - COALESCE(#{@skill}_xp_#{@time}_start, 1000000000) DESC, #{@skill}_ehp - COALESCE(#{@skill}_ehp_#{@time}_start, 100000) DESC, #{@skill}_xp DESC"
       end
     elsif @display == "records"
       unless F2POSRSRanks::Application.config.f2p_skills.include?(@skill)
@@ -266,10 +266,10 @@ class ClansController < ApplicationController
       when "ehp", "lvl"
         @sort_by = "ehp"
         @player_ehp_header = 'hilite'
-        ordering = "IFNULL(#{@skill}_ehp_#{@time}_max, -100000) DESC, IFNULL(#{@skill}_xp_#{@time}_max, -1000000000) DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
+        ordering = "COALESCE(#{@skill}_ehp_#{@time}_max, -100000) DESC, COALESCE(#{@skill}_xp_#{@time}_max, -1000000000) DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
       when "xp"
         @player_xp_header = 'hilite'
-        ordering = "IFNULL(#{@skill}_xp_#{@time}_max, -1000000000) DESC, IFNULL(#{@skill}_ehp_#{@time}_max, -100000) DESC, #{@skill}_xp DESC"
+        ordering = "COALESCE(#{@skill}_xp_#{@time}_max, -1000000000) DESC, COALESCE(#{@skill}_ehp_#{@time}_max, -100000) DESC, #{@skill}_xp DESC"
       end
     end
 

--- a/app/controllers/clans_controller.rb
+++ b/app/controllers/clans_controller.rb
@@ -250,10 +250,10 @@ class ClansController < ApplicationController
       when "ehp", "lvl"
         @sort_by = "ehp"
         @player_ehp_header = 'hilite'
-        ordering = "#{@skill}_ehp - #{@skill}_ehp_#{@time}_start DESC, #{@skill}_xp - #{@skill}_xp_#{@time}_start DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
+        ordering = "#{@skill}_ehp - IFNULL(#{@skill}_ehp_#{@time}_start, 100000) DESC, #{@skill}_xp - IFNULL(#{@skill}_xp_#{@time}_start, 1000000000) DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
       when "xp"
         @player_xp_header = 'hilite'
-        ordering = "#{@skill}_xp - #{@skill}_xp_#{@time}_start DESC, #{@skill}_ehp - #{@skill}_ehp_#{@time}_start DESC, #{@skill}_xp DESC"
+        ordering = "#{@skill}_xp - IFNULL(#{@skill}_xp_#{@time}_start, 1000000000) DESC, #{@skill}_ehp - IFNULL(#{@skill}_ehp_#{@time}_start, 100000) DESC, #{@skill}_xp DESC"
       end
     elsif @display == "records"
       unless F2POSRSRanks::Application.config.f2p_skills.include?(@skill)
@@ -266,10 +266,10 @@ class ClansController < ApplicationController
       when "ehp", "lvl"
         @sort_by = "ehp"
         @player_ehp_header = 'hilite'
-        ordering = "#{@skill}_ehp_#{@time}_max DESC, #{@skill}_xp_#{@time}_max DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
+        ordering = "IFNULL(#{@skill}_ehp_#{@time}_max, -100000) DESC, IFNULL(#{@skill}_xp_#{@time}_max, -1000000000) DESC, #{@skill}_ehp DESC, #{@skill}_xp DESC, players.id ASC"
       when "xp"
         @player_xp_header = 'hilite'
-        ordering = "#{@skill}_xp_#{@time}_max DESC, #{@skill}_ehp_#{@time}_max DESC, #{@skill}_xp DESC"
+        ordering = "IFNULL(#{@skill}_xp_#{@time}_max, -1000000000) DESC, IFNULL(#{@skill}_ehp_#{@time}_max, -100000) DESC, #{@skill}_xp DESC"
       end
     end
 

--- a/app/controllers/clans_controller.rb
+++ b/app/controllers/clans_controller.rb
@@ -145,11 +145,13 @@ class ClansController < ApplicationController
 
     @sort_by = params[:sort_by] || session[:sort_by] || {}
     @skill = params[:skill] || session[:skill] || {}
+    @filter_inactive = params[:filter_inactive] || session[:filter_inactive] || "false"
     @clear_filters = params[:clear_filters]
 
     if @clear_filters
       @sort_by = {}
       @skill = {}
+      @filter_inactive = "false"
     end
 
     if @skill == {}
@@ -161,9 +163,10 @@ class ClansController < ApplicationController
     @display = params[:display] || session[:display] || "stats"
     @time = params[:time] || session[:time] || "week"
 
-    if params[:display] != session[:display] || params[:time] != session[:time]
+    if params[:display] != session[:display] || params[:time] != session[:time] || params[:filter_inactive] != session[:filter_inactive]
       session[:display] = @display
       session[:time] = @time
+      session[:filter_inactive] = @filter_inactive
     end
 
     case @time
@@ -278,6 +281,11 @@ class ClansController < ApplicationController
     end
 
     @players = @clan.players
+
+    if @filter_inactive == "true"
+      @players = @players.where("(overall_xp - overall_xp_month_start) > 0")
+    end
+
     if @skill.include?("ttm")
       @players = @players.where("ttm_lvl != 0 or ttm_xp != 0 or overall_ehp > 1000")
     end

--- a/app/controllers/clans_controller.rb
+++ b/app/controllers/clans_controller.rb
@@ -305,6 +305,59 @@ class ClansController < ApplicationController
     @clan
   end
 
+  def update_clan_description
+    clan_name = params[:id]
+    clan = Clan.find_clan(clan_name)
+    clan_id = clan.id
+
+    if clan.pass != Digest::MD5.hexdigest(params[:pass])
+      redirect_to(clan_admin_path, notice: "Incorrect password. Please try again.")
+    elsif params[:clan_description].size > 1000
+      redirect_to clan_admin_path, notice: "Description is too long. Please limit to 1000 characters."
+    else
+      clan.update_attributes(:description => ActiveRecord::Base.sanitize_sql(params[:clan_description]))
+      redirect_to clan_admin_path, notice: "Clan description updated successfully."
+    end
+  end
+
+  def update_clan_link1
+    clan_name = params[:id]
+    clan = Clan.find_clan(clan_name)
+    clan_id = clan.id
+
+    if clan.pass != Digest::MD5.hexdigest(params[:pass])
+      redirect_to(clan_admin_path, notice: "Incorrect password. Please try again.")
+    elsif params[:link1].empty? or params[:link1_name].empty?
+      redirect_to clan_admin_path, notice: "Link URL and label must not be empty."
+    elsif !params[:link1].include?("http")
+      redirect_to clan_admin_path, notice: "Sorry, the link URL must start with 'http' or 'https'."
+    elsif params[:link1].size > 500 or params[:link1_name].size > 500
+      redirect_to clan_admin_path, notice: "Link URL or label are invalid (too long). Please limit to 500 characters."
+    else
+      clan.update_attributes(:link1 => ActiveRecord::Base.sanitize_sql(params[:link1]), :link1_name => ActiveRecord::Base.sanitize_sql(params[:link1_name]))
+      redirect_to clan_admin_path, notice: "Clan link updated successfully."
+    end
+  end
+
+  def update_clan_link2
+    clan_name = params[:id]
+    clan = Clan.find_clan(clan_name)
+    clan_id = clan.id
+
+    if clan.pass != Digest::MD5.hexdigest(params[:pass])
+      redirect_to(clan_admin_path, notice: "Incorrect password. Please try again.")
+    elsif params[:link2].empty? or params[:link2_name].empty?
+      redirect_to clan_admin_path, notice: "Link URL and label must not be empty."
+    elsif !params[:link2].include?("http")
+      redirect_to clan_admin_path, notice: "Sorry, the link URL must start with 'http' or 'https'."
+    elsif params[:link2].size > 500 or params[:link2_name].size > 500
+      redirect_to clan_admin_path, notice: "Link URL or label are invalid (too long). Please limit to 500 characters."
+    else
+      clan.update_attributes(:link2 => ActiveRecord::Base.sanitize_sql(params[:link2]), :link2_name => ActiveRecord::Base.sanitize_sql(params[:link2_name]))
+      redirect_to clan_admin_path, notice: "Clan link updated successfully."
+    end
+  end
+
   def create
   end
 

--- a/app/views/clans/admin.html.haml
+++ b/app/views/clans/admin.html.haml
@@ -1,23 +1,7 @@
 - @title = "#{@clan.gsub("_", " ")} Admin" 
 = link_to image_tag("f2pwiki.png"), players_path
 
-%p#notice= notice
-
-= content_tag(:div, nil, class: "container", style: "width: 820px;") do 
-  = content_tag(:div, nil, class: ["bar", "ranks"]) do
-    = link_to "Hiscores", ranks_path
-  = content_tag(:div, nil, class: ["bar", "fake"]) do 
-    = link_to "Current Top", tracking_path
-  = content_tag(:div, nil, class: ["bar", "ehp"]) do 
-    = link_to "Records", records_path
-  = content_tag(:div, nil, class: ["bar", "ehp"]) do 
-    = link_to "EHP Rates", ehp_path
-  = content_tag(:div, nil, class: ["bar", "links"]) do 
-    = link_to "Links", links_path
-  = content_tag(:div, nil, class: ["bar", "changelog"]) do 
-    = link_to "Changelog", changelog_path
-  = content_tag(:div, nil, class: ["bar", "donate"]) do 
-    = link_to "About Us/Donate", donate_path
+= render :partial => "header.html.haml",  :locals => {notice: notice}
 
 = "#{@clan.gsub("_", " ")} Admin Page"
 %br
@@ -26,48 +10,87 @@
 %br
 
 = content_tag(:div, nil, class: "container", style: "width: 820px;") do
-  = content_tag(:div, nil, class: ["container", "filter"], style: "margin-left: 15px; width: 140px; height: 146px; display: inline-block;") do 
-    = form_tag add_player_to_clan_path, :method => "post", id: "update-clan-form" do
-      = "Add to Clan"
-      %br
-      = text_field_tag :player_name, params[:player_name], placeholder: "Player Name", :class => "search-field", style: "width: 100px;"
-      %br
-      = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
-      %br
-      = submit_tag "Add"
+  = content_tag(:div, nil, class: "left", style: "width: 420px; margin-left: 5px; padding: 10px;") do
+    %h3 Update Players
+    = content_tag(:div, nil, class: "container", style: "width: 420px;") do
+      = content_tag(:div, nil, class: ["container", "filter"], style: "margin-left: 15px; width: 140px; height: 146px; display: inline-block;") do
+        = form_tag add_player_to_clan_path, :method => "post", id: "update-clan-form" do
+          = "Add to Clan"
+          %br
+          = text_field_tag :player_name, params[:player_name], placeholder: "Player Name", :class => "search-field", style: "width: 100px;"
+          %br
+          = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
+          %br
+          = submit_tag "Add"
 
-  = content_tag(:div, nil, class: ["container"], style: "margin-left: 15px; width: 240px; height: 186px; display: inline-block;") do 
-    = form_tag add_many_players_to_clan_path, :method => "post", id: "update-many-clans-form" do
-      = "Add Multiple Players"
-      %br
-      = "(up to 100 comma separated names)"
-      %br
-      = text_field_tag :player_names, params[:player_names], placeholder: "comma separated names", :class => "search-field", style: "width: 180px; height: 100px;"
-      %br
-      = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
-      %br
-      = submit_tag "Add"
+      = content_tag(:div, nil, class: ["container"], style: "margin-left: 15px; width: 240px; height: 186px; display: inline-block;") do
+        = form_tag add_many_players_to_clan_path, :method => "post", id: "update-many-clans-form" do
+          %br
+          = "Add Multiple Players"
+          %br
+          = text_area_tag :player_names, params[:player_names], placeholder: "up to 100 comma separated names", :class => "search-field", style: "width: 180px; height: 100px;"
+          %br
+          = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
+          %br
+          = submit_tag "Add"
 
-= content_tag(:div, nil, class: "container", style: "width: 520px;") do
+    = content_tag(:div, nil, class: "container", style: "width: 420px;") do
 
-  = content_tag(:div, nil, class: ["container", "filter"], style: "margin-left: 15px; width: 140px; height: 146px; display: inline-block;") do
-    = form_tag remove_player_from_clan_path, :method => "post", id: "update-clan-form" do
-      = "Remove from Clan"
-      %br
-      = text_field_tag :player_name, params[:player_name], placeholder: "Player Name", :class => "search-field", style: "width: 100px;"
-      %br
-      = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
-      %br
-      = submit_tag "Remove"
+      = content_tag(:div, nil, class: ["container", "filter"], style: "margin-left: 15px; width: 140px; height: 146px; display: inline-block;") do
+        = form_tag remove_player_from_clan_path, :method => "post", id: "update-clan-form" do
+          = "Remove from Clan"
+          %br
+          = text_field_tag :player_name, params[:player_name], placeholder: "Player Name", :class => "search-field", style: "width: 100px;"
+          %br
+          = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
+          %br
+          = submit_tag "Remove"
 
-  = content_tag(:div, nil, class: ["container"], style: "margin-left: 15px; width: 240px; height: 186px; display: inline-block;") do
-    = form_tag remove_many_players_from_clan_path, :method => "post", id: "update-many-clans-form" do
-      = "Remove Multiple Players"
-      %br
-      = "(up to 100 comma separated names)"
-      %br
-      = text_field_tag :player_names, params[:player_names], placeholder: "comma separated names", :class => "search-field", style: "width: 180px; height: 100px;"
-      %br
-      = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
-      %br
-      = submit_tag "Remove"
+      = content_tag(:div, nil, class: ["container"], style: "margin-left: 15px; width: 240px; height: 186px; display: inline-block;") do
+        = form_tag remove_many_players_from_clan_path, :method => "post", id: "update-many-clans-form" do
+          %br
+          = "Remove Multiple Players"
+          %br
+          = text_area_tag :player_names, params[:player_names], placeholder: "up to 100 comma separated names", :class => "search-field", style: "width: 180px; height: 100px;"
+          %br
+          = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
+          %br
+          = submit_tag "Remove"
+
+
+  = content_tag(:div, nil, class: "left", style: "width: 280px; margin-left: 25px; padding: 10px;") do
+    %h3 Update Clan Info
+    = content_tag(:div, nil, class: ["container", "left"], style: "margin-left: 15px; width: 240px; height: 186px; display: inline-block;") do
+      = form_tag update_clan_description_path, :method => "post", id: "update-clan-description-form" do
+        %br
+        = "Update Clan Description"
+        %br
+        = text_area_tag :clan_description, params[:clan_description], placeholder: "Clan Description (1000 characters or less)", :class => "search-field", style: "width: 180px; height: 100px;", size: "100"
+        %br
+        = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
+        %br
+        = submit_tag "Add"
+
+    = content_tag(:div, nil, class: ["container", "left"], style: "margin-left: 15px; width: 240px; height: 126px; display: inline-block;") do
+      = form_tag update_clan_link1_path, :method => "post", id: "update-clan-link1-form" do
+        %br
+        = "Update Clan Link 1"
+        = text_field_tag :link1, params[:link1], placeholder: "Link URL, ex: reddit.com/r/clan", :class => "search-field", style: "width: 180px"
+        %br
+        = text_field_tag :link1_name, params[:link1_name], placeholder: "Link label, ex: Reddit", :class => "search-field", style: "width: 180px"
+        %br
+        = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
+        %br
+        = submit_tag "Update"
+
+    = content_tag(:div, nil, class: ["container", "left"], style: "margin-left: 15px; width: 240px; height: 186px; display: inline-block;") do
+      = form_tag update_clan_link2_path, :method => "post", id: "update-clan-link1-form" do
+        %br
+        = "Update Clan Link 2"
+        = text_field_tag :link1, params[:link1], placeholder: "Link URL, ex: discord.gg/abcd", :class => "search-field", style: "width: 180px"
+        %br
+        = text_field_tag :link1_name, params[:link1_name], placeholder: "Link label, ex: Discord", :class => "search-field", style: "width: 180px"
+        %br
+        = password_field_tag :pass, params[:pass], placeholder: "Clan Password", :class => "search-field", style: "width: 100px;"
+        %br
+        = submit_tag "Update"

--- a/app/views/clans/show.html.haml
+++ b/app/views/clans/show.html.haml
@@ -149,6 +149,18 @@
           = link_to "Year", clan_path(:time => "year")
 
     %br
+
+    = content_tag(:div, nil, class: ["container"], style: "margin: auto; width: 540px;") do
+      = @clan.description
+      - if @clan.link1 and @clan.link1_name
+        %br
+        = link_to @clan.link1_name, @clan.link1
+        - if @clan.link2 and @clan.link2_name
+          = "|"
+          = link_to @clan.link2_name, @clan.link2
+
+    %br
+
     = content_tag(:div, nil, class: "container", id: "headerHiscores", style: "margin: auto; width: 530px; height: 50px; margin-bottom: 0px;")
     = content_tag(:table, nil, style: "text-align: center; margin: auto; min-width: 530px; padding: 5px; margin-bottom: 0px;") do
       - if @display == "stats"

--- a/app/views/clans/show.html.haml
+++ b/app/views/clans/show.html.haml
@@ -149,6 +149,14 @@
           = link_to "Year", clan_path(:time => "year")
 
     %br
+    - if @filter_inactive == "true"
+      = link_to "Unfilter inactive?", clan_path(:filter_inactive => "false")
+    - else
+      = link_to "Filter inactive?", clan_path(:filter_inactive => "true")
+
+    = "|"
+    = link_to "Reset filters", clan_path(:clear_filters => "true")
+    %br
 
     = content_tag(:div, nil, class: ["container"], style: "margin: auto; width: 540px;") do
       = @clan.description

--- a/app/views/clans/show.html.haml
+++ b/app/views/clans/show.html.haml
@@ -162,10 +162,10 @@
       = @clan.description
       - if @clan.link1 and @clan.link1_name
         %br
-        = link_to @clan.link1_name, @clan.link1
+        = link_to @clan.link1_name, "#{@clan.link1}"
         - if @clan.link2 and @clan.link2_name
           = "|"
-          = link_to @clan.link2_name, @clan.link2
+          = link_to @clan.link2_name, "#{@clan.link2}"
 
     %br
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,9 @@ Rails.application.routes.draw do
   post 'clans/:id/add_many_players_to_clan' => 'clans#add_many_players_to_clan', as: :add_many_players_to_clan
   post 'clans/:id/remove_player_from_clan' => 'clans#remove_player_from_clan', as: :remove_player_from_clan
   post 'clans/:id/remove_many_players_from_clan' => 'clans#remove_many_players_from_clan', as: :remove_many_players_from_clan
+  post 'clans/:id/update_clan_description' => 'clans#update_clan_description', as: :update_clan_description
+  post 'clans/:id/update_clan_link1' => 'clans#update_clan_link1', as: :update_clan_link1
+  post 'clans/:id/update_clan_link2' => 'clans#update_clan_link2', as: :update_clan_link2
   post 'players#index' => 'players#refresh_250', as: :refresh_250
   post 'players#index' => 'players#refresh_players', as: :refresh_players
   post 'players#secretpage' => 'players#export_players', as: :export_players

--- a/db/migrate/20210301032420_add_description_to_clans.rb
+++ b/db/migrate/20210301032420_add_description_to_clans.rb
@@ -1,0 +1,7 @@
+class AddDescriptionToClans < ActiveRecord::Migration[5.2]
+  def change
+    add_column :clans, :description, :string
+    add_column :clans, :link1, :string
+    add_column :clans, :link2, :string
+  end
+end

--- a/db/migrate/20210301034457_add_link_names_to_clans.rb
+++ b/db/migrate/20210301034457_add_link_names_to_clans.rb
@@ -1,0 +1,6 @@
+class AddLinkNamesToClans < ActiveRecord::Migration[5.2]
+  def change
+    add_column :clans, :link1_name, :string
+    add_column :clans, :link2_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_10_073129) do
+ActiveRecord::Schema.define(version: 2021_03_01_034457) do
 
   create_table "clans", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,11 @@ ActiveRecord::Schema.define(version: 2021_02_10_073129) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "pass"
+    t.string "description"
+    t.string "link1"
+    t.string "link2"
+    t.string "link1_name"
+    t.string "link2_name"
   end
 
   create_table "items", force: :cascade do |t|


### PR DESCRIPTION
Fixes:
* clans/:id with display set to gains or records would incorrectly display NULL results ranked first, instead of ranked last.

Adds:
* clan admins can now set a clan description and up to two clan links
* clans now have "Filter inactive?" and "Clear filters?" buttons
* clan admin page is a _little_ bit cleaner