### PR TITLE
Make the 1 defence filter show players higher than cb level 3

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -158,7 +158,7 @@ class PlayersController < ApplicationController
       @players = @players.where(hitpoints_lvl: 10).where("combat_lvl >= 4")
     end
     if @restrictions["1 defence"]
-      @players = @players.where(defence_lvl: 1)
+      @players = @players.where(defence_lvl: 1).where("combat_lvl >= 4")
     end
     if @restrictions["3 combat"]
       @players = @players.where("combat_lvl < 4")
@@ -281,7 +281,7 @@ class PlayersController < ApplicationController
       @players = @players.where(hitpoints_lvl: 10).where("combat_lvl >= 4")
     end
     if @restrictions["1 defence"]
-      @players = @players.where(defence_lvl: 1)
+      @players = @players.where(defence_lvl: 1).where("combat_lvl >= 4")
     end
     if @restrictions["3 combat"]
       @players = @players.where("combat_lvl < 4")
@@ -413,7 +413,7 @@ class PlayersController < ApplicationController
       @players = @players.where(hitpoints_lvl: 10).where("combat_lvl >= 4")
     end
     if @restrictions["1 defence"]
-      @players = @players.where(defence_lvl: 1)
+      @players = @players.where(defence_lvl: 1).where("combat_lvl >= 4")
     end
     if @restrictions["3 combat"]
       @players = @players.where("combat_lvl < 4")


### PR DESCRIPTION
As part of #111 I made it consistent with the 10 hp filter in that it only shows players with combat level 4 or above