### PR TITLE
[BUGFIX] Fix issue with overall xp being reg int size on prod

### DIFF
--- a/db/migrate/20231029042415_change_overall_xp_to_be_bigint_in_players2.rb
+++ b/db/migrate/20231029042415_change_overall_xp_to_be_bigint_in_players2.rb
@@ -1,0 +1,5 @@
+class ChangeOverallXpToBeBigintInPlayers2 < ActiveRecord::Migration[6.1]
+  def change
+    change_column :players, :overall_xp, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_01_034457) do
+ActiveRecord::Schema.define(version: 2023_10_29_042415) do
 
   create_table "clans", force: :cascade do |t|
     t.string "name"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2021_03_01_034457) do
   create_table "players", force: :cascade do |t|
     t.string "player_name"
     t.string "player_acc_type"
-    t.integer "overall_xp"
+    t.bigint "overall_xp"
     t.integer "overall_lvl"
     t.float "overall_ehp"
     t.integer "attack_xp"


### PR DESCRIPTION
Issue with Netbook pro not being able to update overall xp on live site https://www.f2p.wiki/players/Netbook_Pro

probably because of regular int for some reason

`rails db:migrate`